### PR TITLE
set en_US locale on usDateFormatter

### DIFF
--- a/Classes/ReportParserOperation.m
+++ b/Classes/ReportParserOperation.m
@@ -189,6 +189,7 @@
 
 	NSDateFormatter *usDateFormatter = [[[NSDateFormatter alloc] init] autorelease];
 	[usDateFormatter setDateStyle:NSDateFormatterShortStyle];
+    [usDateFormatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US"]];
 	NSDateFormatter *internationalDateFormatter = [[[NSDateFormatter alloc] init] autorelease];
 	[internationalDateFormatter setDateFormat:@"dd.MM.yyyy"];
 	


### PR DESCRIPTION
FIXES: unable to import reports, when current locale is not en_US
